### PR TITLE
PAT-1871: Fix OWASP dependency issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   java-machine:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202104-01
     environment:
       _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-XX:+UseContainerSupport -Dkotlin.compiler.execution.strategy=in-process
     working_directory: ~/app

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.7"
+  id("org.owasp.dependencycheck") version "6.1.6"
 }
 
 configurations {
@@ -8,7 +9,7 @@ configurations {
 
 dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-    annotationProcessor('org.projectlombok:lombok:1.18.18')
+    annotationProcessor('org.projectlombok:lombok:1.18.20')
 
     runtimeOnly 'com.h2database:h2:1.4.200'
     runtimeOnly 'org.flywaydb:flyway-core:7.7.1'
@@ -58,10 +59,10 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2")
     implementation("com.pauldijou:jwt-core_2.11:5.0.0")
 
-    compileOnly('org.projectlombok:lombok:1.18.18')
+    compileOnly('org.projectlombok:lombok:1.18.20')
 
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.18'
-    testCompileOnly 'org.projectlombok:lombok:1.18.18'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
+    testCompileOnly 'org.projectlombok:lombok:1.18.20'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'io.github.http-builder-ng:http-builder-ng-apache:1.0.4'
@@ -69,5 +70,5 @@ dependencies {
     testImplementation "org.testcontainers:localstack:1.15.2"
     testImplementation "com.github.tomakehurst:wiremock-standalone:2.27.2"
     testImplementation "com.google.code.gson:gson:2.8.6"
-    testImplementation "org.awaitility:awaitility-kotlin:4.0.3"
+    testImplementation "org.awaitility:awaitility-kotlin:4.1.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Details also on the JIRA ticket PAT-1871. 

Summary:-  

* This project uses a Circle machine executor and none are available with JDK 16 pre-installed.
* Instead, I updated this project to use the (later) dps-gradle-spring-boot plugin at v3.1.7, but have also locally overridden the plugin-provided `org.owasp.depdendencyCheck` from v6.1.5 -> v6.1.6 (which fixes the current issues).
* I also updated some specific dependencies for Lombok and to use gradle v.7.0.
* This service remains at Java 11, both in circle and for its base image in the Dockerfile, so we will need to update it to Java 16 at some point in the future i.e. when a circle-ci machine executor is available pre-installed with JDK 16.

It fixes it for now.
