### PR TITLE
SI-465-Switch-Risk-Profiler-to-non-deprecated-APIs-generic-service-chart

### DIFF
--- a/helm_deploy/offender-risk-profiler/Chart.yaml
+++ b/helm_deploy/offender-risk-profiler/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 0.4.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
-    version: 1.5.0
+    version: 2.7.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
SI-465-Switch-Risk-Profiler-to-non-deprecated-APIs-generic-service-chart. Move to using the latest version of the generic service chart (v2.7.3)