### PR TITLE
Feature/si 1212 trivvy fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: si-dev
+    default: sed-dev
   nonprod-releases-slack-channel:
     type: string
     default: sed-nonprod-releases
@@ -29,10 +29,7 @@ parameters:
 executors:
   java-machine:
     machine:
-      #      TODO: this should be upgraded as soon as a java 16+ machine image is available,
-      #        see https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      #      When it is, the kotlinOptions.jvmTarget setting in build.gradle.kts can then be uncommented
-      image: default
+     image: default
     environment:
       _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-XX:+UseContainerSupport -Dkotlin.compiler.execution.strategy=in-process
     working_directory: ~/app
@@ -128,12 +125,6 @@ workflows:
 
   security:
     triggers:
-      - schedule:
-          cron: "10 * * * *"
-          filters:
-            branches:
-              only:
-                - develop
       - schedule:
           cron: "16 3 * * 1-5"
           filters:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,6 @@ configurations {
   all {
     exclude (group="software.amazon.ion", module="ion-java" )
   }
-//  implementation { exclude(module = "json-smart:2.4.8") }
-  // implementation { exclude(module = "applicationinsights-logging-logback") }
-
 }
 
 dependencyCheck {
@@ -49,15 +46,10 @@ dependencies {
 
   implementation("net.minidev:json-smart:2.4.9")
 
-  // implementation("software.amazon.ion:ion-java:1.10.5")
   implementation("org.springframework:spring-expression:5.3.27")
-//  testImplementation("software.amazon.ion:ion-java:1.10.5")
   testImplementation("com.jayway.jsonpath:json-path:2.9.0") {
     exclude(module = "json-smart")
   }
-
-
-  //
 
   implementation("org.springframework.boot:spring-boot-starter:2.7.9")
 
@@ -76,9 +68,6 @@ dependencies {
   // Note spring-data-redis 2.6.2 does not support Jedis 4.x
   implementation("redis.clients:jedis:3.8.0")
 
-  //implementation("com.amazonaws:aws-java-sdk-core:1.12.468") {
- //   exclude(module = "ion-java")
- // }
   implementation("org.springframework:spring-jms:5.3.24")
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.1.2")
 


### PR DESCRIPTION
Reduced critical and several high trivvy vulnerabilities. Currently four left but I think this is due to the cache not clearing the old dependencies that are showing as removed on local machine. current status - 
<img width="833" alt="Screenshot 2024-09-10 at 11 15 40" src="https://github.com/user-attachments/assets/f3dd62bb-fbe5-4514-8b71-a7b8afd2126a">
