### PR TITLE
fix for alerts bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/riskprofiler/model/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/riskprofiler/model/Alert.kt
@@ -9,7 +9,7 @@ data class Alert(
 
   val alertCode: String,
   var dateCreated: LocalDate,
-  val activeFrom: LocalDate,
+  val activeFrom: LocalDate? = null,
   var dateExpires: LocalDate? = null,
   val active: Boolean,
 ) : Serializable {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/riskprofiler/services/SocDecisionTreeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/riskprofiler/services/SocDecisionTreeService.kt
@@ -89,7 +89,7 @@ class SocDecisionTreeService(
 
   private fun isHasActiveSocAlerts(nomsId: String): Boolean {
     return nomisService.getSocListAlertsForOffender(nomsId).stream()
-      .anyMatch { alert -> alert.active && alert.activeFrom.isAfter(LocalDate.now().minusYears(1)) }
+      .anyMatch { alert -> alert.active && alert.dateCreated.isAfter(LocalDate.now().minusYears(1)) }
   }
 
   companion object {


### PR DESCRIPTION
The bug was caused by activeFrom being null on some alerts, it looks like dateCreated should be used instead based on the old API used previously.